### PR TITLE
Implement Firebase push gRPC service

### DIFF
--- a/CrypticPushNotificationService/CrypticPushNotificationService/CrypticPushNotificationService.csproj
+++ b/CrypticPushNotificationService/CrypticPushNotificationService/CrypticPushNotificationService.csproj
@@ -8,10 +8,12 @@
 
   <ItemGroup>
     <Protobuf Include="Protos\greet.proto" GrpcServices="Server" />
+    <Protobuf Include="Protos\push.proto" GrpcServices="Server" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.57.0" />
+    <PackageReference Include="FirebaseAdmin" Version="2.5.0" />
   </ItemGroup>
 
 </Project>

--- a/CrypticPushNotificationService/CrypticPushNotificationService/Program.cs
+++ b/CrypticPushNotificationService/CrypticPushNotificationService/Program.cs
@@ -1,14 +1,26 @@
 using CrypticPushNotificationService.Services;
+using FirebaseAdmin;
+using Google.Apis.Auth.OAuth2;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddGrpc();
 
+var firebasePath = builder.Configuration.GetValue<string>("Firebase:CredentialsPath");
+if (!string.IsNullOrEmpty(firebasePath) && FirebaseApp.DefaultInstance == null)
+{
+    FirebaseApp.Create(new AppOptions
+    {
+        Credential = GoogleCredential.FromFile(firebasePath)
+    });
+}
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
 app.MapGrpcService<GreeterService>();
+app.MapGrpcService<PushNotificationService>();
 app.MapGet("/", () => "Communication with gRPC endpoints must be made through a gRPC client. To learn how to create a client, visit: https://go.microsoft.com/fwlink/?linkid=2086909");
 
 app.Run();

--- a/CrypticPushNotificationService/CrypticPushNotificationService/Protos/push.proto
+++ b/CrypticPushNotificationService/CrypticPushNotificationService/Protos/push.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+option csharp_namespace = "CrypticPushNotificationService";
+
+package push;
+
+// Service for sending push notifications via Firebase Cloud Messaging.
+service PushNotification {
+  // Sends a push notification to a specific device token.
+  rpc Send (PushRequest) returns (PushReply);
+}
+
+// Information about the notification to send.
+message PushRequest {
+  string token = 1;  // FCM device token.
+  string title = 2;  // Notification title.
+  string body = 3;   // Notification body text.
+}
+
+// Result of the push notification request.
+message PushReply {
+  bool success = 1;  // Whether the notification was sent successfully.
+  string error = 2;  // Error message if the send failed.
+}

--- a/CrypticPushNotificationService/CrypticPushNotificationService/Services/PushNotificationService.cs
+++ b/CrypticPushNotificationService/CrypticPushNotificationService/Services/PushNotificationService.cs
@@ -1,0 +1,42 @@
+using CrypticPushNotificationService;
+using Grpc.Core;
+using FirebaseAdmin.Messaging;
+
+namespace CrypticPushNotificationService.Services
+{
+    public class PushNotificationService : PushNotification.PushNotificationBase
+    {
+        private readonly ILogger<PushNotificationService> _logger;
+        private readonly FirebaseMessaging _messaging;
+
+        public PushNotificationService(ILogger<PushNotificationService> logger)
+        {
+            _logger = logger;
+            _messaging = FirebaseMessaging.DefaultInstance;
+        }
+
+        public override async Task<PushReply> Send(PushRequest request, ServerCallContext context)
+        {
+            try
+            {
+                var message = new Message
+                {
+                    Token = request.Token,
+                    Notification = new Notification
+                    {
+                        Title = request.Title,
+                        Body = request.Body
+                    }
+                };
+
+                await _messaging.SendAsync(message);
+                return new PushReply { Success = true };
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to send push notification");
+                return new PushReply { Success = false, Error = ex.Message };
+            }
+        }
+    }
+}

--- a/CrypticPushNotificationService/CrypticPushNotificationService/appsettings.json
+++ b/CrypticPushNotificationService/CrypticPushNotificationService/appsettings.json
@@ -10,5 +10,8 @@
     "EndpointDefaults": {
       "Protocols": "Http2"
     }
+  },
+  "Firebase": {
+    "CredentialsPath": "firebaseCredentials.json"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# cryptic-push-notification-service
+# Cryptic Push Notification Service
+
+This project contains a gRPC microservice that sends push notifications using Firebase Cloud Messaging (FCM). Another application can interact with this service over gRPC and expose REST endpoints if needed.
+
+## Configuration
+
+1. Create a Firebase service account and download the credentials JSON file.
+2. Place the file next to the service (or provide the path) and set the `Firebase:CredentialsPath` value in `appsettings.json` or as an environment variable.
+
+## Running
+
+```bash
+# Build and run the service
+# Requires .NET 8 SDK
+cd CrypticPushNotificationService
+ dotnet run
+```
+
+The service exposes gRPC endpoints defined in `Protos/push.proto`.


### PR DESCRIPTION
## Summary
- add proto definition for push notification service
- implement `PushNotificationService` backed by Firebase
- initialize Firebase in `Program.cs`
- expose gRPC push service
- add Firebase credentials path to configuration
- document setup and usage in README

## Testing
- `dotnet build CrypticPushNotificationService/CrypticPushNotificationService.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a6273fd48320846b666ae7e39938